### PR TITLE
Fix open_basedir restriction issue

### DIFF
--- a/aviary.php
+++ b/aviary.php
@@ -201,10 +201,10 @@ class AviaryPlugin extends Plugin
     public function onAssetsInitialized()
     {
         $js = $this->getJsCode();
-        $this->grav['assets']->addJs('user/plugins/aviary/js/dropzone.js', ['loading' => 'defer']);
-        $this->grav['assets']->addJs('user/plugins/aviary/js/aviary.js', ['loading' => 'defer', 'priority' => 0]);
+        $this->grav['assets']->addJs('plugin://aviary/js/dropzone.js', ['loading' => 'defer']);
+        $this->grav['assets']->addJs('plugin://aviary/js/aviary.js', ['loading' => 'defer', 'priority' => 0]);
         $this->grav['assets']->addInlineJs($js, ['loading' => 'defer']);
-        $this->grav['assets']->addCss('user/plugins/aviary/css/aviary.css');
+        $this->grav['assets']->addCss('plugin://aviary/css/aviary.css');
 
         if ($this->grav['uri']->scheme() == 'http://') {
             $this->grav['assets']->addJs('http://feather.aviary.com/imaging/v3/editor.js');


### PR DESCRIPTION
Enabling the Aviary plugin crashes Grav v1.5.0 / Admin v1.8.8.
This fix is a solution. I checked other non-crashing plugins 
and the current convention if about loading assets is using `plugin://` 
in the beginning of the path. Without this fix, the path was invalid 
and one `/` was missing. Then critical fragment was like 
`.../public_htmluser/plugins...` where the `/` should be before the `user`.
With proposed fix, the path it is being resolved correctly by Grav.